### PR TITLE
Update Evan Amies-Galonski email to personal address

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Populates, maintains and queries an
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),
-    person("Evan", "Amies-Galonski", , "evan@poissonconsulting.ca", role = "ctb",
+    person("Evan", "Amies-Galonski", , "evanamiesgalonski@gmail.com", role = "ctb",
            comment = c(ORCID = "0000-0003-1096-2089"))
            )
 License: MIT + file LICENSE


### PR DESCRIPTION
Replaces `evan@poissonconsulting.ca` (no longer an active address) with Evan's personal email `evanamiesgalonski@gmail.com` in DESCRIPTION.