### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/create.R
+++ b/R/create.R
@@ -10,7 +10,9 @@ ts_create_db <- function(file) {
     utc_offset = -8L
   )
 
-  DBI::dbExecute(conn, "CREATE TABLE Triad (
+  DBI::dbExecute(
+    conn,
+    "CREATE TABLE Triad (
     Triad INTEGER PRIMARY KEY,
     Child  TEXT NOT NULL UNIQUE,
     Parent1 TEXT NOT NULL UNIQUE,
@@ -23,6 +25,7 @@ ts_create_db <- function(file) {
     FOREIGN KEY (Child) REFERENCES Station (Station) ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (Parent1) REFERENCES Station (Station) ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (Parent2) REFERENCES Station (Station) ON UPDATE CASCADE ON DELETE CASCADE
-    );")
+    );"
+  )
   conn
 }

--- a/R/doctor.R
+++ b/R/doctor.R
@@ -1,12 +1,17 @@
 doctor_triad <- function(triad, fix, conn) {
   triad <- c(triad$Child, triad$Parent1, triad$Parent2)
 
-  span <- DBI::dbGetQuery(conn, paste0(
-    "SELECT Station, MIN(DateTimeData) AS Start, MAX(DateTimeData) AS End
+  span <- DBI::dbGetQuery(
+    conn,
+    paste0(
+      "SELECT Station, MIN(DateTimeData) AS Start, MAX(DateTimeData) AS End
     FROM Data
-    WHERE Station ", in_commas(triad), "
+    WHERE Station ",
+      in_commas(triad),
+      "
     GROUP BY Station"
-  ))
+    )
+  )
 
   span$Start <- as.POSIXct(span$Start, tz = "Etc/GMT+8")
   span$End <- as.POSIXct(span$End, tz = "Etc/GMT+8")
@@ -52,7 +57,9 @@ doctor_triad <- function(triad, fix, conn) {
   na1 <- !na0 & !na2
 
   inconsistent <- (na1 & !is.na(triad1$Corrected)) |
-    (na0 & (is.na(triad1$Corrected) | triad1$Corrected != triad2$Corrected + triad3$Corrected)) |
+    (na0 &
+      (is.na(triad1$Corrected) |
+        triad1$Corrected != triad2$Corrected + triad3$Corrected)) |
     (na0 & triad1$Status < pmax(triad2$Status, triad3$Status))
 
   triad1$Corrected[na0] <- triad2$Corrected[na0] + triad3$Corrected[na0]
@@ -68,7 +75,9 @@ doctor_triad <- function(triad, fix, conn) {
       inconsistent = numeric(0),
       stringsAsFactors = FALSE
     ))
-  } else if (fix) ts_add_data(data = triad1, resolution = "replace", conn = conn)
+  } else if (fix) {
+    ts_add_data(data = triad1, resolution = "replace", conn = conn)
+  }
   data.frame(
     Station = triad[1],
     inconsistent = nrow(triad1),
@@ -82,12 +91,14 @@ doctor_triad <- function(triad, fix, conn) {
 #' @param check_triads A flag indicating whether to check if triads are consistent.
 #' @return A flag indicating whether or not the database passed the checks (or was fixed)
 #' @export
-ts_doctor_db <- function(check_limits = TRUE,
-                         check_period = TRUE,
-                         check_gaps = TRUE,
-                         check_triads = TRUE,
-                         fix = FALSE,
-                         conn = getOption("tsdbr.conn", NULL)) {
+ts_doctor_db <- function(
+  check_limits = TRUE,
+  check_period = TRUE,
+  check_gaps = TRUE,
+  check_triads = TRUE,
+  fix = FALSE,
+  conn = getOption("tsdbr.conn", NULL)
+) {
   flag <- tsdbr::ts_doctor_db(
     check_limits = check_limits,
     check_period = check_period,
@@ -106,7 +117,9 @@ ts_doctor_db <- function(check_limits = TRUE,
     triads <- do.call("rbind", triads)
     if (nrow(triads)) {
       message(
-        "the following stations ", ifelse(fix, "had", "have"), " inconsistent triads:\n",
+        "the following stations ",
+        ifelse(fix, "had", "have"),
+        " inconsistent triads:\n",
         paste0(utils::capture.output(triads), collapse = "\n")
       )
     }

--- a/R/read-bch.R
+++ b/R/read-bch.R
@@ -26,9 +26,17 @@ ts_read_bch <- function(file = "tscbh.xls") {
   data <- data[which(colnames(data) == "Hour"):ncol(data)]
   class <- vapply(data, function(x) class(x)[1], "")
   posix <- which(class == "POSIXct")
-  if (!length(posix)) stop("data must have at least column with Date values after 'Hour'", call. = FALSE)
+  if (!length(posix)) {
+    stop(
+      "data must have at least column with Date values after 'Hour'",
+      call. = FALSE
+    )
+  }
   if (ncol(data) == posix[length(posix)]) {
-    stop("data must have at least column after the last column with Date values", call. = FALSE)
+    stop(
+      "data must have at least column after the last column with Date values",
+      call. = FALSE
+    )
   }
   datas <- list()
   for (i in seq_along(posix)) {

--- a/R/read-brd.R
+++ b/R/read-brd.R
@@ -16,12 +16,16 @@ ts_read_brd <- function(file = "brd.csv", utc_offset = -8L) {
 
   data <- utils::read.csv(file, stringsAsFactors = FALSE)
 
-  check_data(data, values = list(
-    TIME = "",
-    BRD_FLOWS_AVG = 1,
-    BRD_QSPILL_AVG = 1,
-    BRX_FLOW_AVG = 1
-  ), x_name = file)
+  check_data(
+    data,
+    values = list(
+      TIME = "",
+      BRD_FLOWS_AVG = 1,
+      BRD_QSPILL_AVG = 1,
+      BRX_FLOW_AVG = 1
+    ),
+    x_name = file
+  )
 
   brd <- data[c("TIME", "BRD_FLOWS_AVG")]
   brs <- data[c("TIME", "BRD_QSPILL_AVG")]
@@ -38,7 +42,8 @@ ts_read_brd <- function(file = "brd.csv", utc_offset = -8L) {
   rm(brd, brs, brx)
 
   data$DateTime <- lubridate::parse_date_time(
-    data$TIME, c("YmdHM", "YmdHMS", "dmYHM", "dmYHMS"),
+    data$TIME,
+    c("YmdHM", "YmdHMS", "dmYHM", "dmYHMS"),
     tz = ts_utc_offset_to_tz(utc_offset)
   )
 
@@ -46,7 +51,10 @@ ts_read_brd <- function(file = "brd.csv", utc_offset = -8L) {
 
   data$Recorded <- data$Recorded * 0.028316847
 
-  data$Status <- ordered("reasonable", c("reasonable", "questionable", "erroneous"))
+  data$Status <- ordered(
+    "reasonable",
+    c("reasonable", "questionable", "erroneous")
+  )
 
   data <- data[c("Station", "DateTime", "Recorded", "Status")]
 

--- a/R/read-zrxp.R
+++ b/R/read-zrxp.R
@@ -6,13 +6,23 @@ process_meta <- function(ele, utc_offset) {
   station <- sub("#REXCHANGE", "", station, useBytes = TRUE)
   station <- sub("\\|\\*\\|.+", "", station, useBytes = TRUE)
 
-  if (!length(station) || length(station) > 1L || !station %in% .station_lookup$station) {
+  if (
+    !length(station) ||
+      length(station) > 1L ||
+      !station %in% .station_lookup$station
+  ) {
     station <- grep("TSPATH", x, useBytes = TRUE, value = TRUE)
     station <- sub(".*TSPATH\\/08N\\/", "", station)
     station <- sub("\\|\\*\\|.*", "", station)
     station <- gsub("\\/", "_", station)
 
-    if (!length(station) || length(station) > 1L || !station %in% .station_lookup$station_alt) stop("Cannot parse station name from file meta data.")
+    if (
+      !length(station) ||
+        length(station) > 1L ||
+        !station %in% .station_lookup$station_alt
+    ) {
+      stop("Cannot parse station name from file meta data.")
+    }
 
     station <- .station_lookup$station[station == .station_lookup$station_alt]
   }
@@ -52,12 +62,15 @@ process_data <- function(ele, utc_offset) {
   x <- matrix(x, nrow = nrow, ncol = ncol, byrow = T)
   x <- as.data.frame(x)
 
-  if (identical(ncol(x), 2L)) x$Status_BCH <- NA_integer_
+  if (identical(ncol(x), 2L)) {
+    x$Status_BCH <- NA_integer_
+  }
 
   colnames(x) <- c("DateTime", "Recorded", "Status_BCH")
 
   x$DateTime <- as.character(x$DateTime)
-  x$DateTime <- as.POSIXct(x$DateTime,
+  x$DateTime <- as.POSIXct(
+    x$DateTime,
     tz = ts_utc_offset_to_tz(utc_offset),
     format = "%Y%m%d%H%M%S"
   )
@@ -97,7 +110,9 @@ ts_read_zrxp <- function(file = "tscbh.zrxp", utc_offset = -8L) {
   meta <- grep("#REXCHANGE", lines, useBytes = TRUE)
   meta2 <- grep("#ZRXPVERSION", lines, useBytes = TRUE)
 
-  if (length(meta2)) meta <- meta2
+  if (length(meta2)) {
+    meta <- meta2
+  }
 
   dat <- grep("#LAYOUT\\(.+\\)\\|\\*\\|", lines, useBytes = TRUE) + 1
 
@@ -122,7 +137,11 @@ ts_read_zrxp <- function(file = "tscbh.zrxp", utc_offset = -8L) {
       x$meta$Station
     })
     lack <- unlist(lack)
-    warning("the following stations lack data: ", punctuate(lack), call. = FALSE)
+    warning(
+      "the following stations lack data: ",
+      punctuate(lack),
+      call. = FALSE
+    )
     ls[bol] <- NULL
   }
 
@@ -132,15 +151,22 @@ ts_read_zrxp <- function(file = "tscbh.zrxp", utc_offset = -8L) {
     grepl("secondary", tolower(x$meta$Station))
   })
 
-  if (any(sec)) ls <- ls[-which(sec)]
+  if (any(sec)) {
+    ls <- ls[-which(sec)]
+  }
 
   ls <- lapply(ls, process_data, utc_offset = utc_offset)
   ls <- lapply(ls, merge_meta_data)
 
   data <- do.call("rbind", ls)
 
-  data$Status <- ordered("reasonable", c("reasonable", "questionable", "erroneous"))
-  data$Status[!is.na(data$Status_BCH) & data$Status_BCH %in% c(55, 200)] <- "questionable"
+  data$Status <- ordered(
+    "reasonable",
+    c("reasonable", "questionable", "erroneous")
+  )
+  data$Status[
+    !is.na(data$Status_BCH) & data$Status_BCH %in% c(55, 200)
+  ] <- "questionable"
   data <- data[c("Station", "DateTime", "Recorded", "Status")]
   data <- data[order(data$Station, data$DateTime), ]
   row.names(data) <- NULL

--- a/R/triad.R
+++ b/R/triad.R
@@ -6,7 +6,12 @@
 #' @inheritParams tsdbr::ts_disconnect_db
 #' @return A data frame of the imported triad.
 #' @export
-ts_add_triad <- function(child, parent1, parent2, conn = getOption("tsdbr.conn", NULL)) {
+ts_add_triad <- function(
+  child,
+  parent1,
+  parent2,
+  conn = getOption("tsdbr.conn", NULL)
+) {
   chk_string(child)
   chk_string(parent1)
   chk_string(parent2)
@@ -27,7 +32,8 @@ ts_add_triad <- function(child, parent1, parent2, conn = getOption("tsdbr.conn",
 #' @return The imported triad data.
 #' @export
 ts_add_triads <- function(triads, conn = getOption("tsdbr.conn", NULL)) {
-  check_data(triads,
+  check_data(
+    triads,
     values = list(
       Child = "",
       Parent1 = "",
@@ -35,7 +41,6 @@ ts_add_triads <- function(triads, conn = getOption("tsdbr.conn", NULL)) {
     ),
     nrow = TRUE
   )
-
 
   triads <- triads[c("Child", "Parent1", "Parent2")]
 

--- a/R/write.R
+++ b/R/write.R
@@ -44,7 +44,8 @@
 #' @return An invisible copy of saved data.
 #' @export
 ts_write_csv <- function(data, file = "tsdbr.csv") {
-  check_data(data,
+  check_data(
+    data,
     values = list(
       Station = "",
       DateTime = Sys.time()

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -6,19 +6,25 @@ test_that("read_bch", {
 
   expect_identical(nrow(bch), 26304L)
 
-  expect_identical(bch[1, ], tibble::as_tibble(data.frame(
-    DateTime = as.POSIXct("1992-01-01 00:00:00", tz = "Etc/GMT+8"),
-    Recorded = 0,
-    stringsAsFactors = FALSE
-  )))
+  expect_identical(
+    bch[1, ],
+    tibble::as_tibble(data.frame(
+      DateTime = as.POSIXct("1992-01-01 00:00:00", tz = "Etc/GMT+8"),
+      Recorded = 0,
+      stringsAsFactors = FALSE
+    ))
+  )
 
   expect_identical(nrow(bch2), 8760L)
 
-  expect_identical(bch2[1, ], tibble::as_tibble(data.frame(
-    DateTime = as.POSIXct("2001-01-01 00:00:00", tz = "Etc/GMT+8"),
-    Recorded = NA_real_,
-    stringsAsFactors = FALSE
-  )))
+  expect_identical(
+    bch2[1, ],
+    tibble::as_tibble(data.frame(
+      DateTime = as.POSIXct("2001-01-01 00:00:00", tz = "Etc/GMT+8"),
+      Recorded = NA_real_,
+      stringsAsFactors = FALSE
+    ))
+  )
 })
 
 test_that("read_zrxp", {
@@ -30,14 +36,23 @@ test_that("read_zrxp", {
   zrxp <- rbind(zrxp, zrxp2, zrxp3)
 
   expect_identical(nrow(zrxp), 46249L)
-  expect_identical(colnames(zrxp), c("Station", "DateTime", "Recorded", "Status"))
-  expect_identical(zrxp[1, ], tibble::as_tibble(data.frame(
-    Station = "ALH_TurbineFlow",
-    DateTime = as.POSIXct("2015-03-31 00:00:00", tz = "Etc/GMT+8"),
-    Recorded = 0,
-    Status = ordered("reasonable", c("reasonable", "questionable", "erroneous")),
-    stringsAsFactors = FALSE
-  )))
+  expect_identical(
+    colnames(zrxp),
+    c("Station", "DateTime", "Recorded", "Status")
+  )
+  expect_identical(
+    zrxp[1, ],
+    tibble::as_tibble(data.frame(
+      Station = "ALH_TurbineFlow",
+      DateTime = as.POSIXct("2015-03-31 00:00:00", tz = "Etc/GMT+8"),
+      Recorded = 0,
+      Status = ordered(
+        "reasonable",
+        c("reasonable", "questionable", "erroneous")
+      ),
+      stringsAsFactors = FALSE
+    ))
+  )
 
   zrxp <- ts_read_zrxp(file = file.path(dir, "data_2022_format.zrxp"))
   expect_true(all(unique(zrxp$Station) %in% .station_lookup$station))
@@ -56,14 +71,23 @@ test_that("read_brd", {
   brd <- rbind(brd, brd2)
 
   expect_identical(nrow(brd), 13101L)
-  expect_identical(colnames(brd), c("Station", "DateTime", "Recorded", "Status"))
+  expect_identical(
+    colnames(brd),
+    c("Station", "DateTime", "Recorded", "Status")
+  )
   brd$Recorded <- signif(brd$Recorded, 7)
 
-  expect_identical(brd[1, ], tibble::as_tibble(data.frame(
-    Station = "BRD_FLOWS_AVG",
-    DateTime = as.POSIXct("2015-01-01 00:00:00", tz = "Etc/GMT+8"),
-    Recorded = 140.2369,
-    Status = ordered("reasonable", c("reasonable", "questionable", "erroneous")),
-    stringsAsFactors = FALSE
-  )))
+  expect_identical(
+    brd[1, ],
+    tibble::as_tibble(data.frame(
+      Station = "BRD_FLOWS_AVG",
+      DateTime = as.POSIXct("2015-01-01 00:00:00", tz = "Etc/GMT+8"),
+      Recorded = 140.2369,
+      Status = ordered(
+        "reasonable",
+        c("reasonable", "questionable", "erroneous")
+      ),
+      stringsAsFactors = FALSE
+    ))
+  )
 })

--- a/tests/testthat/test-zzz-package.R
+++ b/tests/testthat/test-zzz-package.R
@@ -1,7 +1,9 @@
 test_that("package", {
   file <- ":memory:"
   # file <- "tscbh.sqlite"
-  if (file.exists(file)) unlink(file)
+  if (file.exists(file)) {
+    unlink(file)
+  }
   conn <- ts_create_db(file = file)
   teardown(ts_disconnect_db(conn))
   options(tsdbr.conn = conn)
@@ -14,16 +16,24 @@ test_that("package", {
   # stations
   stations <- data.frame(
     Station = c(
-      "DDM", "DDM_SPOG", "DDM_LLOG", "DDM_SPOG1",
-      "DDM_SPOG2", "DDM_LLOG1", "DDM_LLOG2"
+      "DDM",
+      "DDM_SPOG",
+      "DDM_LLOG",
+      "DDM_SPOG1",
+      "DDM_SPOG2",
+      "DDM_LLOG1",
+      "DDM_LLOG2"
     ),
     Parameter = "discharge",
     Site = "Duncan Dam",
     Period = "hour",
     StationID = c(
-      "Duncan_Releases", "Duncan_SPOG_Releases",
-      "Duncan_LLOG_Releases", "Duncan_SPOG1_Releases",
-      "Duncan_SPOG2_Releases", "Duncan_LLOG1_Releases",
+      "Duncan_Releases",
+      "Duncan_SPOG_Releases",
+      "Duncan_LLOG_Releases",
+      "Duncan_SPOG1_Releases",
+      "Duncan_SPOG2_Releases",
+      "Duncan_LLOG1_Releases",
       "Duncan_LLOG2_Releases"
     ),
     stringsAsFactors = FALSE
@@ -55,35 +65,71 @@ test_that("package", {
   zrxp <- ts_translate_stations(zrxp)
   zrxp <- zrxp[!is.na(zrxp$Station), ]
   zrxp$Recorded[dttr2::dtt_hour(zrxp$DateTime) == 1] <- NA
-  zrxp$Recorded[zrxp$Station == "DDM_LLOG1" & dttr2::dtt_hour(zrxp$DateTime) == 2] <- NA
-  zrxp$Recorded[zrxp$Station == "DDM" & dttr2::dtt_hour(zrxp$DateTime) == 3] <- NA
-  zrxp$Status[zrxp$Station == "DDM_LLOG1" & dttr2::dtt_hour(zrxp$DateTime) == 4] <- "questionable"
-  zrxp$Status[zrxp$Station == "DDM_LLOG2" & dttr2::dtt_hour(zrxp$DateTime) == 5] <- "erroneous"
+  zrxp$Recorded[
+    zrxp$Station == "DDM_LLOG1" & dttr2::dtt_hour(zrxp$DateTime) == 2
+  ] <- NA
+  zrxp$Recorded[
+    zrxp$Station == "DDM" & dttr2::dtt_hour(zrxp$DateTime) == 3
+  ] <- NA
+  zrxp$Status[
+    zrxp$Station == "DDM_LLOG1" & dttr2::dtt_hour(zrxp$DateTime) == 4
+  ] <- "questionable"
+  zrxp$Status[
+    zrxp$Station == "DDM_LLOG2" & dttr2::dtt_hour(zrxp$DateTime) == 5
+  ] <- "erroneous"
   zrxp$Recorded[zrxp$Station == "DDM" & dttr2::dtt_hour(zrxp$DateTime) == 6] <-
-    zrxp$Recorded[zrxp$Station == "DDM" & dttr2::dtt_hour(zrxp$DateTime) == 6] + 1
+    zrxp$Recorded[zrxp$Station == "DDM" & dttr2::dtt_hour(zrxp$DateTime) == 6] +
+    1
 
   expect_is(ts_add_data(zrxp), "data.frame")
-  expect_error(ts_add_data(zrxp), "UNIQUE constraint failed: Data.Station, Data.DateTimeData")
-  data <- ts_get_data(start_date = as.Date("2015-03-31"), end_date = as.Date("2015-04-01"))
+  expect_error(
+    ts_add_data(zrxp),
+    "UNIQUE constraint failed: Data.Station, Data.DateTimeData"
+  )
+  data <- ts_get_data(
+    start_date = as.Date("2015-03-31"),
+    end_date = as.Date("2015-04-01")
+  )
 
   # doctor
-  expect_message(ts_doctor_db(), "the following stations have inconsistent triads.*1\\s+DDM_SPOG\\s+23.*2\\s+DDM_LLOG\\s+22\\s$")
-  expect_message(ts_doctor_db(fix = TRUE), "the following stations had inconsistent triads.*1\\s+DDM_SPOG\\s+23.*2\\s+DDM_LLOG\\s+22\\s.*3\\s+DDM\\s+5\\s$")
-  expect_message(ts_doctor_db(), "the following stations have gaps in their data.*1\\s+DDM_LLOG\\s+2.*2\\s+DDM_SPOG\\s+1\\s$")
+  expect_message(
+    ts_doctor_db(),
+    "the following stations have inconsistent triads.*1\\s+DDM_SPOG\\s+23.*2\\s+DDM_LLOG\\s+22\\s$"
+  )
+  expect_message(
+    ts_doctor_db(fix = TRUE),
+    "the following stations had inconsistent triads.*1\\s+DDM_SPOG\\s+23.*2\\s+DDM_LLOG\\s+22\\s.*3\\s+DDM\\s+5\\s$"
+  )
+  expect_message(
+    ts_doctor_db(),
+    "the following stations have gaps in their data.*1\\s+DDM_LLOG\\s+2.*2\\s+DDM_SPOG\\s+1\\s$"
+  )
   expect_true(ts_doctor_db(fix = TRUE))
 
   data <- ts_get_data(
-    start_date = as.Date("2015-03-31"), end_date = as.Date("2015-03-31"),
+    start_date = as.Date("2015-03-31"),
+    end_date = as.Date("2015-03-31"),
     status = "erroneous"
   )
 
-  ddm <- data[data$Station == "DDM" & dttr2::dtt_hour(data$DateTime) %in% c(1, 3, 6), ]
+  ddm <- data[
+    data$Station == "DDM" & dttr2::dtt_hour(data$DateTime) %in% c(1, 3, 6),
+  ]
 
   expect_identical(ddm$Corrected, c(NA, 111.596, 111.451))
   expect_identical(ddm$Recorded, c(NA, NA, 112.451))
   expect_identical(ddm$Status, ts_integer_to_status(rep(1L, 3)))
-  llog <- data[data$Station == "DDM_LLOG" & dttr2::dtt_hour(data$DateTime) %in% c(1, 2, 4, 5), ]
+  llog <- data[
+    data$Station == "DDM_LLOG" &
+      dttr2::dtt_hour(data$DateTime) %in% c(1, 2, 4, 5),
+  ]
   expect_identical(llog$Corrected, c(NA, NA, 111.542, 111.505))
   expect_identical(llog$Recorded, rep(NA_real_, 4))
-  expect_identical(llog$Status, ordered(c("reasonable", "reasonable", "questionable", "erroneous"), c("reasonable", "questionable", "erroneous")))
+  expect_identical(
+    llog$Status,
+    ordered(
+      c("reasonable", "reasonable", "questionable", "erroneous"),
+      c("reasonable", "questionable", "erroneous")
+    )
+  )
 })


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)